### PR TITLE
Add const to input_fmt in LibAvEncoder::initAudioInCodec

### DIFF
--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -129,7 +129,7 @@ void LibAvEncoder::initVideoCodec(VideoOptions const *options, StreamInfo const 
 
 void LibAvEncoder::initAudioInCodec(VideoOptions const *options, StreamInfo const &info)
 {
-	AVInputFormat *input_fmt = (AVInputFormat *)av_find_input_format("pulse");
+	const AVInputFormat *input_fmt = (AVInputFormat *)av_find_input_format("pulse");
 
 	assert(in_fmt_ctx_ == nullptr);
 	int ret = avformat_open_input(&in_fmt_ctx_, options->audio_device.c_str(), input_fmt, nullptr);


### PR DESCRIPTION
Hey folks, ran into a compile error building this against ffmpeg 5.0 - the compiler really wanted the input_fmt to be const.